### PR TITLE
Set default port for project to run with

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -50,3 +50,4 @@ lazy val microservice = Project(appName, file("."))
   .settings(
     resolvers += Resolver.jcenterRepo
   )
+  .settings(PlayKeys.playDefaultPort := 9774)


### PR DESCRIPTION
If we set this property in `build.sbt` when we use `sbt run` the project will run on the correct port automatically.